### PR TITLE
Correct dependency installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ or, for brevity,
   Examples
 ================================
 
-* Declare the dependency to clj-stripe in your project.clj
+* Add clj-stripe to the `:dependencies` list in your project.clj:
 
 ```
-:dependencies [abengoa/clj-stripe "1.0.4"]
+[abengoa/clj-stripe "1.0.4"]
 ```
 
 * Import the namespaces you may need


### PR DESCRIPTION
``` clojure
:dependencies [abengoa/clj-stripe "1.0.4"]
```

is syntactically valid Clojure but Leiningen requires `:dependencies` to be a vector of vectors.
So simply tell the user what the artifact/version pair is, the rest can be trivially figured out even by beginners.
